### PR TITLE
Don't crash when no frigg-file is provided

### DIFF
--- a/frigg_settings/model.py
+++ b/frigg_settings/model.py
@@ -17,7 +17,7 @@ class FriggSettings(object):
         if obj is None:
             return
 
-        if isinstance(obj['tasks'], list):
+        if 'tasks' in obj and isinstance(obj['tasks'], list):
             obj = self.convert_v1_to_v2(obj)
 
         self.update(obj)
@@ -25,7 +25,9 @@ class FriggSettings(object):
     def update(self, obj):
         tasks = self.tasks
         self.__dict__.update(obj)
-        tasks.update(obj['tasks'])
+        if 'tasks' in obj:
+            tasks.update(obj['tasks'])
+
         self.tasks = tasks
 
     def validate(self):

--- a/frigg_settings/settings.py
+++ b/frigg_settings/settings.py
@@ -12,7 +12,7 @@ def build_tasks(directory, runner):
 
 def load_settings_file(path, runner):
     if path is None:
-        return {}
+        return None
 
     content = yaml.load(runner.read_file(path))
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -22,8 +22,7 @@ def test_filesystemwrapper_list_files():
 def test_filesystemwrapper_read_file():
     wrapper = FileSystemWrapper()
     assert(
-        wrapper.read_file(path('MANIFEST.in'))
-        ==
+        wrapper.read_file(path('MANIFEST.in')) ==
         'include setup.py README.md MANIFEST.in LICENSE\n'
     )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,3 +42,7 @@ def test_has_after_tasks_should_return_correct_value_for_unsuccessful_builds():
 def test_model_should_create_new_objects():
     FriggSettings({'tasks': {'tests': ['tox']}})
     assert FriggSettings({'tasks': {'setup': ['tox']}}).tasks['tests'] != ['tox']
+
+
+def test_model_without_tasks():
+    assert 'setup' in FriggSettings({}).tasks

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -35,6 +35,10 @@ def test_load_settings_file(mocker, runner, settings_file):
     mock_read_file.assert_called_once_with('.frigg.yml')
 
 
+def test_load_settings_file_no_path(runner):
+    assert load_settings_file(None, runner) is None
+
+
 def test_build_settings(mocker, runner, settings_dict):
     mocker.patch('frigg_settings.settings.detect_tox_environments',
                  return_value=['tests', 'flake8'])


### PR DESCRIPTION
https://github.com/frigg/frigg-settings/commit/925c470833f8973e10d833c4825c5e3cd335c18d fixes this, however I also added a commit that makes sure it doesn't crash if the frigg-file doesn't contain any tasks. I think this is decent default behavior, as it'll let frigg_test_discovery do its stuff even if a frigg-file exists (but with no tasks).
